### PR TITLE
Workh jsonify time

### DIFF
--- a/bigsky/json2cky.py
+++ b/bigsky/json2cky.py
@@ -234,10 +234,10 @@ def treeify_time(intervals, now):
     # else: 2+ intervals, not starting now
     trees = [treeify_interval(intvl, now) for intvl in intervals]
     ans = ['TIME', trees[0], 'and', trees[1]]
-    for t in trees[2:]:
-        if t[0] >= 29:
+    for i in range(2, len(trees)):
+        if intervals[i][0] >= 29:
             return ['TIME', ans, 'and', ['TIME',['BTIME', 'tomorrow']]]
-        ans = ['TIME', ans, 'and', t]
+        ans = ['TIME', ans, 'and', trees[i]]
     return ans
 
 

--- a/test/test_json2cky.py
+++ b/test/test_json2cky.py
@@ -1,6 +1,6 @@
 import unittest
 from bigsky.json2cky import treeify_weather, stringify_tree, stringify_hour
-from bigsky.json2cky import treeify_interval
+from bigsky.json2cky import treeify_interval, treeify_time
 
 
 class TestCky(unittest.TestCase):
@@ -20,11 +20,11 @@ class TestCky(unittest.TestCase):
         
     def test_treeify_interval(self):
         expected = ['TIME', ['BTIME', 'in', 'the', ['TIMEWORD', 'morning']]]
-        assert treeify_interval((6,10), 3) == expected
+        assert treeify_interval([6,10], 3) == expected
         expected = ['TIME', 'until', ['BTIME', 'later', 'this', 'morning']]
-        assert treeify_interval((6,10), 6) == expected
+        assert treeify_interval([6,10], 6) == expected
         expected = ['TIME', ['BTIME', 'later', 'this', 'morning']]
-        assert treeify_interval((6,10), 7) == expected
+        assert treeify_interval([6,10], 7) == expected
         expected = ['TIME',
                      'starting',
                      ['BTIME', 'this', ['TIMEWORD', 'morning']],
@@ -32,7 +32,22 @@ class TestCky(unittest.TestCase):
                      'continuing',
                      'until',
                      ['BTIME', 'tomorrow', ['TIMEWORD', 'night']]]
-        assert treeify_interval((6,47), 1) == expected
+        assert treeify_interval([6,47], 1) == expected
+    
+    def test_treeify_time(self):
+        expected = ['TIME', 'until', ['BTIME', 'later', 'this', 'morning']]
+        assert treeify_time([[6,10]], 6) == expected
+        expected = ['TIME', 'starting', ['BTIME', 'later', 'tonight'], 
+                    ',', 'continuing', 'until', ['BTIME', 'this', ['TIMEWORD', 'morning']]]  
+        assert treeify_time([[1,3],[3,7],[6,9]] , 0) == expected
+        expected = ['TIME', 'until', ['BTIME', 'this', ['TIMEWORD', 'afternoon']],
+                     ',', 'starting', 'again', ['BTIME', 'this', ['TIMEWORD', 'afternoon']]]
+        assert treeify_time([[6, 13],[15,20]], 6) == expected
+        ### I should note, the CFG will not be able to parse this last one because it doesn't like "TIME and TIME"
+        expected = ['TIME', ['TIME', ['TIME', ['BTIME', 'later', 'this', 'morning']], 
+                                'and', ['TIME', ['BTIME', 'in', 'the', ['TIMEWORD', 'afternoon']]]], 
+                            'and', ['TIME', ['BTIME', 'tomorrow']]]  
+        assert treeify_time([[8,9],[13,14],[30,33]],6) == expected
         
   
 if __name__ == "__main__":


### PR DESCRIPTION
added function `treeify_time` (or completed it), which will take a list of intervals (which are themselves length-2 lists now), and turn it into a tree under a TIME node. notes on this: 
- I am not generating "throughout the day"
- I am making, in the case of long lists of intervals, a structure that is not strictly allowed by the grammar - I would need this rule:
    ```TIME -> TIME and TIME```
- Lastly, I'm merging intervals that overlap on their endpoints (ie `[[1,5],[4,7],[7,9]]` becomes `[[1,9]]`)

Also, ∃ unittests